### PR TITLE
Finer increments of font size; set max size to the default size

### DIFF
--- a/jquery.inputfit.js
+++ b/jquery.inputfit.js
@@ -6,15 +6,23 @@
 (function($){
     $.fn.inputfit = function(options) {
         var settings = $.extend({
-			minSize   : 12,
-			maxSize   : 24
+            minSize   : 12,
+            maxSize   : 24,
+            useCurrentSizeAsMax : true
         }, options);
 
-            this.each(function(){
-                if (!$(this).is(':input'))
+            this.each(function() {
+                if ( !$(this).is(':input') ) {
                     return;
+                }
+                
+                var maxSize = settings.maxSize;
+                
+                if( settings.useCurrentSizeAsMax ) {
+                    maxSize = parseFloat( $(this).css('font-size') );
+                }
 
-                $(this).bind('keydown',function(){
+                $(this).bind('keyup', function(event) {
                     var $this   = $(this),
                         cloneId = this.id + '_size-changing-clone',
                         width   = $(this).width();
@@ -38,7 +46,11 @@
 
                     if ( clone.width() < width - 10 ) {
                         while ( clone.width() < width - 20 ) {
-                            if ( currentFontSize < settings.maxSize ) { currentFontSize+=.1  } else { break; }
+                            if ( currentFontSize < maxSize ) {
+                                currentFontSize += .1;
+                            } else {
+                                break;
+                            }
                             clone.css('font-size', currentFontSize + 'px');
                         }
                         $this.css('font-size', currentFontSize + 'px');
@@ -46,7 +58,11 @@
                     } else {
 
                         while ( clone.width() > width - 20 ) {
-                            if ( currentFontSize > settings.minSize ) { currentFontSize-=.10  } else { break; }
+                            if ( currentFontSize > settings.minSize ) {
+                                currentFontSize -= .1;
+                            } else {
+                                break;
+                            }
                             clone.css('font-size', currentFontSize + 'px');
                         }
                         $this.css('font-size', currentFontSize + 'px');


### PR DESCRIPTION
I implemented two changes:
1. Increments of font size are made in tenths of a pixel. This seems strange, but it is supported by the CSS spec and works correctly in the latest browsers. The result is a smoother decrease of size to fit the input.
2. Added an option, enabled by default, to limit the font size to the default font size dictated by CSS. In other words, if you remove text from the input, it won't make it bigger than the initial style dictated.
