### PR TITLE
Added option to adjust input width instead of font size

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,8 +1,10 @@
 #jquery.inputfit.js
-Plugin that makes value of the input fit into the input, see the [demo](http://vxsx.github.io/jquery.inputfit.js/)
-Plugin fits text by changing the font-size, so you should set min and
-max font-size values. If you don't specify max font-size, plugin assumes current font-size
-is maximum.
+Plugin that makes the input fit the value or the value fit the input.
+See the [demo](http://vxsx.github.io/jquery.inputfit.js/)
+Plugin fits text by either changing the font-size or the width of the
+input, depending on your settings. You can set min and max font-size
+and width values values. If you don't specify max font-size, plugin
+assumes current font-size is maximum.
 
 
 Requires
@@ -12,8 +14,9 @@ Requires
 Default options
 
 ``` javascript
-minSize : 10
-maxSize : false
+minSize    : 10
+maxSize    : false
+resizeType : "font-size"
 ```
 
 Using:

--- a/README.markdown
+++ b/README.markdown
@@ -16,15 +16,17 @@ Default options
 ``` javascript
 minSize    : 10
 maxSize    : false
-resizeType : "font-size"
+resizeType : "font-size" // or "width"
 ```
 
 Using:
 
 ``` html
 <input type="text" name="younameit" id="input">
+<input type="text" name="younameit" id="input-width">
 <script type="text/javascript">
-    $('input').inputfit();
+    $('#input').inputfit();
+    $('#input-width').inputfit({ resizeType: "width" });
 </script>
 ```
 

--- a/README.markdown
+++ b/README.markdown
@@ -1,10 +1,7 @@
 #jquery.inputfit.js
-Plugin that makes the input fit the value or the value fit the input.
-See the [demo](http://vxsx.github.io/jquery.inputfit.js/)
-Plugin fits text by either changing the font-size or the width of the
-input, depending on your settings. You can set min and max font-size
-and width values values. If you don't specify max font-size, plugin
-assumes current font-size is maximum.
+Plugin that makes the input fit the value or the value fit the input. See the [demo](http://vxsx.github.io/jquery.inputfit.js/)
+
+Plugin fits text by either changing the font-size or the width of the input, depending on your settings. You can set min and max font-size and width values values. If you don't specify max font-size, plugin assumes current font-size is maximum.
 
 
 Requires

--- a/index.html
+++ b/index.html
@@ -14,17 +14,13 @@
             font-family: Helvetica;
               overflow-x: hidden;
               overflow-y: auto;
+              padding-top: 240px;
         }
         .b-input-wrapper {
-            height: 70px;
             font-size: 24px;
             text-align: center;
-            position: absolute;
-            top: 50%;
-            left: 50%;
-            margin-left: -218px;
-            margin-top: -30px;
             width: 436px;
+            margin:0 auto 60px;
         }
         input {
             width: 250px;
@@ -32,23 +28,37 @@
             line-height: 30px;
             font-size: 24px;
             text-align: left;
+            margin-bottom:6px;
         }
         label {
             font-size: 16px;
             color: #a0a0a0;
+            display: block;
         }
-        #github { color: white; right: -65px; height: 30px; top: 40px; position: absolute; text-decoration: none; width: 250px; opacity: 1; -moz-transform: rotate(45deg); -webkit-transform: rotate(45deg); -o-transform: rotate(45deg); -ms-transform: rotate(45deg); transform: rotate(45deg); } #github span { background: #000; font-size: 14px; left: 0; position: absolute; text-align: center; width: 250px; -moz-box-shadow: rgba(0, 0, 0, 0.2) 1px 1px 10px; -webkit-box-shadow: rgba(0, 0, 0, 0.2) 1px 1px 10px; -o-box-shadow: rgba(0, 0, 0, 0.2) 1px 1px 10px; box-shadow: rgba(0, 0, 0, 0.2) 1px 1px 10px; padding: 5px 0; opacity: 1; -moz-transition: opacity linear 0.2s; -webkit-transition: opacity linear 0.2s; -o-transition: opacity linear 0.2s; transition: opacity linear 0.2s; -webkit-backface-visibility: hidden; -webkit-transition: all linear 0.2s; } #github span:last-child { background: #65BDFB; -webkit-transform: rotatex(180deg); -moz-transform: rotatex(180deg); opacity: 0; } #github:hover span:first-child { opacity: 0; -webkit-transform: rotatex(180deg); -moz-transform: rotatex(180deg); } #github:hover span:last-child { opacity: 1; -webkit-transform: rotatex(360deg); -moz-transform: rotatex(360deg); }
+        h2 {
+          font-size: 24px;
+          margin-bottom: 12px;
+        }
+        #github { color: white; right: -65px; height: 30px; top: 40px; position: fixed; text-decoration: none; width: 250px; opacity: 1; -moz-transform: rotate(45deg); -webkit-transform: rotate(45deg); -o-transform: rotate(45deg); -ms-transform: rotate(45deg); transform: rotate(45deg); } #github span { background: #000; font-size: 14px; left: 0; position: absolute; text-align: center; width: 250px; -moz-box-shadow: rgba(0, 0, 0, 0.2) 1px 1px 10px; -webkit-box-shadow: rgba(0, 0, 0, 0.2) 1px 1px 10px; -o-box-shadow: rgba(0, 0, 0, 0.2) 1px 1px 10px; box-shadow: rgba(0, 0, 0, 0.2) 1px 1px 10px; padding: 5px 0; opacity: 1; -moz-transition: opacity linear 0.2s; -webkit-transition: opacity linear 0.2s; -o-transition: opacity linear 0.2s; transition: opacity linear 0.2s; -webkit-backface-visibility: hidden; -webkit-transition: all linear 0.2s; } #github span:last-child { background: #65BDFB; -webkit-transform: rotatex(180deg); -moz-transform: rotatex(180deg); opacity: 0; } #github:hover span:first-child { opacity: 0; -webkit-transform: rotatex(180deg); -moz-transform: rotatex(180deg); } #github:hover span:last-child { opacity: 1; -webkit-transform: rotatex(360deg); -moz-transform: rotatex(360deg); }
     </style>
     <script>
         $(function(){
             $('#input').inputfit();
+            $('#input-width').inputfit({ resizeType: "width" });
         })
     </script>
 </head>
 <body>
 	<a href="http://github.com/vxsx/jquery.inputfit.js" id="github"><span>Fork me on GitHub</span><span>Be nice!</span></a>
     <div class="b-input-wrapper">
+        <h2>Adjust Font Size</h2>
         <input id="input" name="input" type="text" /><br>
+        <label for="input">Try to enter a long line, for example "Everybody loves github"</label>
+    </div>
+
+    <div class="b-input-wrapper">
+        <h2>Adjust Input Width</h2>
+        <input id="input-width" name="input" type="text" /><br>
         <label for="input">Try to enter a long line, for example "Everybody loves github"</label>
     </div>
 </body>

--- a/jquery.inputfit.js
+++ b/jquery.inputfit.js
@@ -10,8 +10,9 @@
 }(function ($) {
     $.fn.inputfit = function(options) {
         var settings = $.extend({
-            minSize   : 10,
-            maxSize   : false
+            minSize    : 10,
+            maxSize    : false,
+            resizeType : "font-size"
         }, options);
 
         this.each(function() {
@@ -41,20 +42,35 @@
                 $input.data('inputfit-clone', clone);
             }
 
-            $input.on('keyup.inputfit keydown.inputfit', function() {
+            $input.on('keydown.inputfit', function() {
                 var $this = $(this);
 
-                clone.html($this.val().replace(/ /g, '&nbsp;'));
+                // Set 1ms timeout, otherwise value isn't yet updated on keydown event
+                setTimeout(function(){
+                    clone.html($this.val().replace(/ /g, '&nbsp;'));
 
-                var ratio = width / (clone.width() || 1),
-                    currentFontSize = parseInt( $this.css('font-size'), 10 ),
-                    fontSize = Math.floor(currentFontSize * ratio);
+                    if (settings.resizeType == "width") {
+                        // 2 as an arbitrary number for a little extra padding so text doesn't get cut off
+                        var inputWidth = clone.width() + 2;
 
-                if (fontSize > maxSize) { fontSize = maxSize; }
-                if (fontSize < settings.minSize) { fontSize = settings.minSize; }
+                        if(settings.maxSize && inputWidth > maxSize) { inputWidth = maxSize; }
+                        if(inputWidth < settings.minSize) { inputWidth = settings.minSize; }
 
-                $this.css('font-size', fontSize);
-                clone.css('font-size', fontSize);
+                        $this.css('width', inputWidth);
+                    } else {
+                        var ratio = width / (clone.width() || 1),
+                            currentFontSize = parseInt( $this.css('font-size'), 10 ),
+                            fontSize = Math.floor(currentFontSize * ratio);
+
+                        if (fontSize > maxSize) { fontSize = maxSize; }
+                        if (fontSize < settings.minSize) { fontSize = settings.minSize; }
+
+                        $this.css('font-size', fontSize);
+                        clone.css('font-size', fontSize);
+                    }
+                }, 1);
+
+
             });
         });
 


### PR DESCRIPTION
I used this script on a project where I wanted to adjust the width of an inline input instead of the font size. You could technically do this by setting the size attribute of the input based on the number of characters, but in my experience the size wasn't always consistent, so this gets the true pixel width of the input's value. I thought this would be a nice addition to this plugin, since it uses the same cloning technique.

I also updated the documentation and demo. 
